### PR TITLE
Fix Base64 decoding issues

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -262,11 +262,7 @@ module Mail
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      results = []
-      previous_encoding = nil
-      lines = str.split(FULL_ENCODED_VALUE)
-      
-      lines
+      str.split(FULL_ENCODED_VALUE)
     end
   end
 end

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -265,22 +265,8 @@ module Mail
       results = []
       previous_encoding = nil
       lines = str.split(FULL_ENCODED_VALUE)
-      lines.each_slice(2) do |unencoded, encoded|
-        if encoded
-          encoding = value_encoding_from_string(encoded)
-          if encoding == previous_encoding && unencoded.blank?
-            results.last << encoded
-          else
-            results << unencoded unless unencoded == EMPTY
-            results << encoded
-          end
-          previous_encoding = encoding
-        else
-          results << unencoded
-        end
-      end
-
-      results
+      
+      lines
     end
   end
 end


### PR DESCRIPTION
Encodings.collapse_adjacent_encodings breaks Base64 decoding.  Handle decoding individually instead of trying to concatenate multiple Base64 encodings.  The collapsing may work fine with Quoted-Printable, but will fail miserably based on the Base64 standard.
