### PR TITLE
Fix base64 decode issue

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -268,22 +268,7 @@ module Mail
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      lines = str.split(/(\?=)\s*(=\?)/).each_slice(2).map(&:join)
-      results = []
-      previous_encoding = nil
-
-      lines.each do |line|
-        encoding = split_value_encoding_from_string(line)
-
-        if encoding == previous_encoding
-          line = results.pop + line
-        end
-
-        previous_encoding = encoding
-        results << line
-      end
-
-      results
+      Array(str.split(/(\?=)\s*(=\?)/).join)
     end
   end
 end

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -268,7 +268,21 @@ module Mail
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      Array(str.split(/(\?=)\s*(=\?)/).join)
+      #Array(str.split(/(\?=)\s*(=\?)/).join)
+      lines = str.split(/(\?=)\s*(=\?)/).each_slice(2).map(&:join)
+      results = []
+      previous_encoding = nil
+      lines.each do |line|
+        encoding = split_value_encoding_from_string(line)
+        if encoding == previous_encoding
+          line = results.pop + line
+        end
+        
+        previous_encoding = encoding
+        results << line
+      end
+      
+      results
     end
   end
 end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -154,7 +154,7 @@ describe Mail::Encodings do
       expect(Mail::Encodings.value_decode(string)).to eq(string)
     end
 
-    it "should collapse adjacent words" do
+    it "should parse adjacent words with linear white-space" do
       string = "=?utf-8?B?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?=\n =?utf-8?B?0LXQtdCy?="
       result = "новый сотрудник — дорофеев"
       expect(Mail::Encodings.value_decode(string)).to eq(result)


### PR DESCRIPTION
Collapsing base64 encoded-words into a single encoded-word is not prudent.  Additional processing would be necessary, and in my opinion, outweighs any benefit of collapsing the encoded-words.  I would rename the method if it is even necessary to remove the linear white-space between adjacent encoded-words (if the proper stripping of LWSP is not handled elsewhere.)
